### PR TITLE
Add link to other pelican variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ MENUITEMS = (
     ('Archive', '/' + ARCHIVES_SAVE_AS),
 )
 ```
-
+Other variables defined as standard in PELICAN
+http://docs.getpelican.com/en/stable/settings.html
 
 License
 -------


### PR DESCRIPTION
Some normal pelican global variables are used in the templates but not expressly declared in the README so add a link to them